### PR TITLE
Safer tests, better readability when setting JRuby compile mode

### DIFF
--- a/assets/Rakefile
+++ b/assets/Rakefile
@@ -80,7 +80,7 @@ end
 
 desc 'Start the emulator with larger disk'
 task :emulator do
-  system 'emulator -partition-size 1024 -avd Android_3.0'
+  sh 'emulator -partition-size 1024 -avd Android_3.0'
 end
 
 task :start do
@@ -182,8 +182,8 @@ end
 task :test => :uninstall do
   Dir.chdir('test') do
     puts 'Running tests'
-    system "adb uninstall #{package}.tests"
-    system "ant run-tests"
+    sh "adb uninstall #{package}.tests"
+    sh "ant run-tests"
   end
 end
 

--- a/assets/src/org/ruboto/Script.java
+++ b/assets/src/org/ruboto/Script.java
@@ -102,9 +102,8 @@ public class Script {
                     JRUBY_VERSION = "ERROR";
                 }
                 ruby = scriptingContainerClass.getConstructor().newInstance();
-                Class<?> compileModeClass = Class
-                        .forName("org.jruby.RubyInstanceConfig$CompileMode", true, classLoader);
-                callScriptingContainerMethod(Void.class, "setCompileMode", compileModeClass.getEnumConstants()[2]);
+                Class compileModeClass = Class.forName("org.jruby.RubyInstanceConfig$CompileMode", true, classLoader);
+                callScriptingContainerMethod(Void.class, "setCompileMode", Enum.valueOf(compileModeClass, "OFF"));
 
                 // callScriptingContainerMethod(Void.class, "setClassLoader", classLoader);
         	    Method setClassLoaderMethod = ruby.getClass().getMethod("setClassLoader", ClassLoader.class);
@@ -136,7 +135,7 @@ public class Script {
                 // FIXME(uwe): ScriptingContainer not found in the platform APK...
                 e.printStackTrace();
             } catch (IllegalArgumentException e) {
-                // TODO Auto-generated catch block
+                Log.e(TAG, "IllegalArgumentException starting JRuby: " + e.getMessage());
                 e.printStackTrace();
             } catch (SecurityException e) {
                 // TODO Auto-generated catch block


### PR DESCRIPTION
- Set JRuby compile mode by string instead of array index to avoid error if index changes.  Also better readability.
- Use sh instead of system to detect failure in Rakefile
