### PR TITLE
Fixed update_scripts and stack tests

### DIFF
--- a/assets/Rakefile
+++ b/assets/Rakefile
@@ -21,6 +21,7 @@ TEST_APK_FILE      = File.expand_path "test/bin/#{build_project_name}Test-debug.
 JRUBY_JARS         = Dir[File.expand_path 'libs/jruby-*.jar']
 RESOURCE_FILES     = Dir[File.expand_path 'res/**/*']
 JAVA_SOURCE_FILES  = Dir[File.expand_path 'src/**/*.java']
+RUBY_SOURCE_FILES  = Dir[File.expand_path 'src/**/*.rb']
 
 CLEAN.include('tmp', 'bin')
 
@@ -46,9 +47,26 @@ end
 desc 'build debug package'
 task :debug => APK_FILE
 
+namespace :debug do
+  desc 'build debug package if compiled files have changed'
+  task :quick => [MANIFEST_FILE, RUBOTO_CONFIG_FILE, BUNDLE_JAR] + JRUBY_JARS + JAVA_SOURCE_FILES + RESOURCE_FILES do |t|
+    build_apk(t)
+  end
+end
+
 desc "build package and install it on the emulator or device"
 task :install => APK_FILE do
   install_apk
+end
+
+namespace :install do
+  desc 'uninstall, build, and install the application'
+  task :clean => [:uninstall, APK_FILE, :install]
+
+  desc 'Install the application, but only if compiled files are changed.'
+  task :quick => 'debug:quick' do
+    install_apk
+  end
 end
 
 task :release do
@@ -98,54 +116,21 @@ task :uninstall do
   uninstall_apk
 end
 
-namespace :install do
-  desc 'Uninstall, build, and install the application'
-  task :clean => [:uninstall, APK_FILE, :install]
-end
-
 file MANIFEST_FILE
 file RUBOTO_CONFIG_FILE
 
-file APK_FILE => [MANIFEST_FILE, RUBOTO_CONFIG_FILE, BUNDLE_JAR] + JRUBY_JARS + JAVA_SOURCE_FILES + RESOURCE_FILES do |t|
-  if File.exist?(APK_FILE)
-    changed_prereqs = t.prerequisites.select do |p|
-      File.exist?(p) && !Dir[p].empty? && Dir[p].map{|f| File.mtime(f)}.max > File.mtime(APK_FILE)
-    end
-    next if changed_prereqs.empty?
-    changed_prereqs.each{|f| puts "#{f} changed."}
-    puts "Forcing rebuild of #{APK_FILE}."
-  end
-  sh 'ant debug'
+file APK_FILE => [MANIFEST_FILE, RUBOTO_CONFIG_FILE, BUNDLE_JAR] + JRUBY_JARS + JAVA_SOURCE_FILES + RESOURCE_FILES + RUBY_SOURCE_FILES do |t|
+  build_apk(t)
 end
 
 desc 'Copy scripts to emulator or device'
-task :update_scripts do
-  if device_path_exists?(sdcard_path)
-    data_dir_name = 'public'
-    data_dir = sdcard_path
-  elsif device_path_exists?(app_files_path)
-    data_dir_name = 'private'
-    data_dir = app_files_path
-  else
-    puts 'Cannot find the scripts directory on the device.'
-    unless manifest.root.elements["uses-permission[@android:name='android.permission.WRITE_EXTERNAL_STORAGE']"]
-      puts 'If you have a non-rooted device, you need to add'
-      puts %q{    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />}
-      puts 'to the AndroidManifest.xml file to enable the update_scripts rake task.'
-    end
-    puts "Reverting to uninstalling and re-installing the apk."
-    Rake::Task[:uninstall].reenable
-    Rake::Task[:uninstall].invoke
-    FileUtils.rm_f APK_FILE
-    Rake::Task[APK_FILE].reenable
-    Rake::Task[APK_FILE].invoke
-    Rake::Task[:install].reenable
-    Rake::Task[:install].invoke
-    next
-  end
-  Rake::Task['install'].invoke
+task :update_scripts => ['install:quick'] do
+  data_dir_name = 'public'
+  data_dir = "#{sdcard_path}/scripts"
+  `adb shell mkdir -p #{data_dir}` if !device_path_exists?(data_dir)
   puts "Pushing files to apk #{data_dir_name} file area."
   last_update = File.exists?(UPDATE_MARKER_FILE) ? Time.parse(File.read(UPDATE_MARKER_FILE)) : Time.parse('1970-01-01T00:00:00')
+  # TODO(uwe): Use `adb sync src` instead?
   Dir.chdir('src') do
     Dir["**/*.rb"].each do |script_file|
       next if File.directory? script_file
@@ -166,7 +151,7 @@ end
 task :update_test_scripts do
   test_scripts_path = "/data/data/#{package}.tests/files/scripts"
   # TODO(uwe): Investigate if we can just push the scripts instead of building and installing the instrumentation APK
-  if package_installed?(true) && device_path_exists?(test_scripts_path)
+  if false && package_installed?(true) && device_path_exists?(test_scripts_path)
     Dir['test/assets/scripts/*.rb'].each do |script|
       print "#{script}: " ; $stdout.flush
       `adb push #{script} #{test_scripts_path}`
@@ -331,6 +316,18 @@ def replace_faulty_code(faulty_file, faulty_code)
   else
     puts "Could not find expected faulty code\n\n#{faulty_code}\n\nin file #{faulty_file}\n\n#{old_code}\n\n"
   end
+end
+
+def build_apk(t)
+  if File.exist?(APK_FILE)
+    changed_prereqs = t.prerequisites.select do |p|
+      File.exist?(p) && !Dir[p].empty? && Dir[p].map{|f| File.mtime(f)}.max > File.mtime(APK_FILE)
+    end
+    return if changed_prereqs.empty?
+    changed_prereqs.each{|f| puts "#{f} changed."}
+    puts "Forcing rebuild of #{APK_FILE}."
+  end
+  sh 'ant debug'
 end
 
 def install_apk

--- a/assets/test/assets/scripts/test_helper.rb
+++ b/assets/test/assets/scripts/test_helper.rb
@@ -1,13 +1,13 @@
 require 'java'
 
-def assert(value, message = "#{value.inspect} expected to be true")
-  raise message unless value
+def assert(value, message = nil)
+  raise "#{"#{message}\n" if message}#{value.inspect} expected to be true" unless value
 end
 
-def assert_equal(expected, actual, message = "'#{expected}' expected, but got '#{actual}'")
-  raise message unless expected == actual
+def assert_equal(expected, actual, message = nil)
+  raise "#{"#{message}\n" if message}'#{expected}' expected, but got '#{actual}'" unless expected == actual
 end
 
-def assert_less_than_or_equal(limit, actual, message = "Expected '#{actual}' to be less than or equal to '#{limit}'")
-  raise message unless actual <= limit
+def assert_less_than_or_equal(limit, actual, message = nil)
+  raise "#{"#{message}\n" if message}Expected '#{actual}' to be less than or equal to '#{limit}'" unless actual <= limit
 end

--- a/test/activity/stack_activity_test.rb
+++ b/test/activity/stack_activity_test.rb
@@ -11,8 +11,11 @@ setup do |activity|
 end
 
 test('stack depth is 44 or less') do |activity|
-  assert_less_than_or_equal 44, activity.find_view_by_id(42).text.to_i
-  assert_less_than_or_equal 68, activity.find_view_by_id(43).text.to_i
-  assert_less_than_or_equal 77, activity.find_view_by_id(44).text.to_i
-  assert_less_than_or_equal 96, activity.find_view_by_id(45).text.to_i
+  os_offset = {13 => 1}[android.os.Build::VERSION::SDK_INT].to_i
+  jruby_offset = {'1.5.6' => -1}[org.jruby.runtime.Constants::VERSION].to_i
+  version_message ="ANDROID: #{android.os.Build::VERSION::SDK_INT}, JRuby: #{org.jruby.runtime.Constants::VERSION}"
+  assert_equal 44 + os_offset + jruby_offset * 2, activity.find_view_by_id(42).text.to_i, version_message
+  assert_equal 68 + os_offset + jruby_offset * 5, activity.find_view_by_id(43).text.to_i, version_message
+  assert_equal 77 + os_offset + jruby_offset * 6, activity.find_view_by_id(44).text.to_i, version_message
+  assert_equal 96 + os_offset + jruby_offset * 8, activity.find_view_by_id(45).text.to_i, version_message
 end

--- a/test/ruboto_gen_test.rb
+++ b/test/ruboto_gen_test.rb
@@ -30,18 +30,3 @@ class RubotoGenTest < Test::Unit::TestCase
   end
 
 end
-
-if not RubotoTest::ON_JRUBY_JARS_1_5_6
-  class RubotoGenWithPsychTest < RubotoGenTest
-    def setup
-      generate_app :with_psych => true
-    end
-
-    def test_psych_jar_exists
-      assert File.exists?("#{APP_DIR}/libs/psych.jar"), "Failed to generate psych jar"
-    end
-
-  end
-else
-  puts "Skipping Psych tests on jruby-jars-1.5.6"
-end

--- a/test/ruboto_gen_with_psych_test.rb
+++ b/test/ruboto_gen_with_psych_test.rb
@@ -1,0 +1,16 @@
+require File.expand_path("ruboto_gen_test", File.dirname(__FILE__))
+
+if not RubotoTest::ON_JRUBY_JARS_1_5_6
+  class RubotoGenWithPsychTest < RubotoGenTest
+    def setup
+      generate_app :with_psych => true
+    end
+
+    def test_psych_jar_exists
+      assert File.exists?("#{APP_DIR}/libs/psych.jar"), "Failed to generate psych jar"
+    end
+
+  end
+else
+  puts "Skipping Psych tests on jruby-jars-1.5.6"
+end

--- a/test/ruboto_update_test.rb
+++ b/test/ruboto_update_test.rb
@@ -1,51 +1,5 @@
-require File.expand_path("test_helper", File.dirname(__FILE__))
-require 'test/app_test_methods'
-
-module UpdateTestMethods
-  include RubotoTest
-
-  def setup(with_psych = false)
-    generate_app(:with_psych => with_psych, :update => true)
-  end
-
-  def teardown
-    cleanup_app
-  end
-  
-  def test_properties_and_ant_file_has_no_duplicates
-    Dir.chdir APP_DIR do
-      assert File.readlines('test/build.properties').grep(/\w/).uniq!.nil?, 'Duplicate lines in build.properties'
-      assert_equal 1, File.readlines('test/build.xml').grep(/<macrodef name="run-tests-helper">/).size, 'Duplicate macro in build.xml'
-    end
-  end
-
-  def test_icons_are_untouched
-    Dir.chdir APP_DIR do
-      assert_equal 4100, File.size('res/drawable-hdpi/icon.png')
-    end
-  end
-
-end
+require File.expand_path("update_test_methods", File.dirname(__FILE__))
 
 class RubotoUpdateTest < Test::Unit::TestCase
   include UpdateTestMethods
-  include AppTestMethods
-end
-
-if not RubotoTest::ON_JRUBY_JARS_1_5_6
-  class RubotoUpdateWithPsychTest < Test::Unit::TestCase
-    include UpdateTestMethods
-    include AppTestMethods
-
-    def setup
-      super(true)
-    end
-    
-    def test_psych_jar_exists
-      assert File.exists?("#{APP_DIR}/libs/psych.jar"), "Failed to generate psych jar"
-    end
-  
-  end
-else
-  puts "Skipping Psych tests on jruby-jars-1.5.6"
 end

--- a/test/ruboto_update_with_psych_test.rb
+++ b/test/ruboto_update_with_psych_test.rb
@@ -1,0 +1,18 @@
+require File.expand_path("update_test_methods", File.dirname(__FILE__))
+
+if not RubotoTest::ON_JRUBY_JARS_1_5_6
+  class RubotoUpdateWithPsychTest < Test::Unit::TestCase
+    include UpdateTestMethods
+
+    def setup
+      super(true)
+    end
+    
+    def test_psych_jar_exists
+      assert File.exists?("#{APP_DIR}/libs/psych.jar"), "Failed to generate psych jar"
+    end
+  
+  end
+else
+  puts "Skipping Psych tests on jruby-jars-1.5.6"
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -168,16 +168,6 @@ class Test::Unit::TestCase
     end
   end
 
-  def wait_for_dir(dir)
-    puts "Waiting for app to generate script directory: #{dir}"
-    start = Time.now
-    loop do
-      break if `adb shell ls -d #{dir}`.chomp =~ %r{^#{dir}$}
-      flunk 'Timeout waiting for scripts directory to appear' if Time.now > start + 120
-      sleep 1
-    end
-  end
-
   def exclude_stdlibs(excluded_stdlibs)
     puts "Adding ruboto.yml: #{excluded_stdlibs.join(' ')}"
     File.open('ruboto.yml', 'w') { |f| f << YAML.dump({:excluded_stdlibs => excluded_stdlibs}) }

--- a/test/update_test_methods.rb
+++ b/test/update_test_methods.rb
@@ -1,0 +1,29 @@
+require File.expand_path("test_helper", File.dirname(__FILE__))
+require 'test/app_test_methods'
+
+module UpdateTestMethods
+  include RubotoTest
+  include AppTestMethods
+
+  def setup(with_psych = false)
+    generate_app(:with_psych => with_psych, :update => true)
+  end
+
+  def teardown
+    cleanup_app
+  end
+
+  def test_properties_and_ant_file_has_no_duplicates
+    Dir.chdir APP_DIR do
+      assert File.readlines('test/build.properties').grep(/\w/).uniq!.nil?, 'Duplicate lines in build.properties'
+      assert_equal 1, File.readlines('test/build.xml').grep(/<macrodef name="run-tests-helper">/).size, 'Duplicate macro in build.xml'
+    end
+  end
+
+  def test_icons_are_untouched
+    Dir.chdir APP_DIR do
+      assert_equal 4100, File.size('res/drawable-hdpi/icon.png')
+    end
+  end
+
+end


### PR DESCRIPTION
- Placed the custom scripts directory first in the load path
- Moved responsibility for creating the custom xripts directory from the app to the Rakefile.  This enables fast script updates to apps without write access to the sdcard
- Fixed reading scripts from sdcard in development
- Fixed stack test for Android 3.2 and JRuby 1.5.6
- Separated ruboto gen/update tests with psych to enable running them separately
