### PR TITLE
Fixed bug: gen app on a path with spaces

### DIFF
--- a/lib/ruboto/util/update.rb
+++ b/lib/ruboto/util/update.rb
@@ -11,7 +11,7 @@ module Ruboto
         if !File.exists?("#{root}/test")
           name = verify_strings.root.elements['string'].text.gsub(' ', '')
           puts "\nGenerating Android test project #{name} in #{root}..."
-          system "android create test-project -m #{root.gsub(/\ /,'\ ')} -n #{name}Test -p #{root.gsub(/\ /,'\ ')}/test"
+          system %Q{android create test-project -m "#{root.gsub('"', '\"')}" -n "#{name}Test" -p "#{root.gsub('"', '\"')}/test"}
           FileUtils.rm_rf File.join(root, 'test', 'src', verify_package.split('.'))
           puts "Done"
         else


### PR DESCRIPTION
Hello!

I've found a bug when I'm generating a new app on a path with spaces.

For example, when I'm at "~/Applications/Open Source/" and I run ruboto gen app --path ./example etc ... I got the following error:

Generating Android test project Example in /Users/thiagoalessio/Applications/Open Source/example...
Error: Argument 'Source/example/test' is not recognized.

I know my solution is dirty ... using sys.escape (from Rant http://rant.rubyforge.org/) sounds better ... but add a new dependency is a big decision, so I'll let it for you ;D
