### PR TITLE
* Issue #147 Class oriented definition of activities, services, broadcast receivers and callback objects

### DIFF
--- a/assets/samples/sample_service.rb
+++ b/assets/samples/sample_service.rb
@@ -1,17 +1,17 @@
 require 'ruboto/service'
 require 'ruboto/util/toast'
 
-$context.start_ruboto_service do
-  # Services are complicated and don't really make sense unless you
-  # show the interaction between the Service and other parts of your
-  # app.
-  # For now, just take a look at the explanation and example in
-  # online:
-  # http://developer.android.com/reference/android/app/Service.html
+# Services are complicated and don't really make sense unless you
+# show the interaction between the Service and other parts of your
+# app.
+# For now, just take a look at the explanation and example in
+# online:
+# http://developer.android.com/reference/android/app/Service.html
+class SampleService
+  include Ruboto::Service
 
   def on_start_command(intent, flags, startId)
     toast "Hello from the service"
-    self.class::START_NOT_STICKY
+    android.app.Service::START_NOT_STICKY
   end
-
 end

--- a/assets/src/InheritingService.java
+++ b/assets/src/InheritingService.java
@@ -2,6 +2,7 @@ package THE_PACKAGE;
 
 public class InheritingService extends org.ruboto.RubotoService {
 	public void onCreate() {
+	    System.out.println("InheritingService.onCreate()");
 		setScriptName("sample_service.rb");
 		super.onCreate();
 	}

--- a/assets/src/RubotoActivity.java
+++ b/assets/src/RubotoActivity.java
@@ -78,10 +78,8 @@ THE_CONSTANTS
     protected void loadScript() {
         try {
             if (scriptName != null) {
-    	        Script.setScriptFilename(getClass().getClassLoader().getResource(scriptName).getPath());
-                Script.execute(new Script(scriptName).getContents());
-                // String rubyClassName = getClass().getSimpleName();
-                String rubyClassName = toCamelCase(scriptName);
+                new Script(scriptName).execute();
+                String rubyClassName = Script.toCamelCase(scriptName);
                 System.out.println("Looking for Ruby class: " + rubyClassName);
                 Object rubyClass = Script.get(rubyClassName);
                 if (rubyClass != null) {
@@ -103,25 +101,6 @@ THE_CONSTANTS
             e.printStackTrace();
             ProgressDialog.show(this, "Script failed", "Something bad happened", true, true);
         }
-    }
-
-    static private String toSnakeCase(String s) {
-        return s.replaceAll(
-            String.format("%s|%s|%s",
-                "(?<=[A-Z])(?=[A-Z][a-z])",
-                "(?<=[^A-Z])(?=[A-Z])",
-                "(?<=[A-Za-z])(?=[^A-Za-z])"
-            ),
-            "_"
-        ).toLowerCase();
-    }
-
-    static private String toCamelCase(String s) {
-        String[] parts = s.replace(".rb", "").split("_");
-        for (int i = 0 ; i < parts.length ; i++) {
-            parts[i] = parts[i].substring(0,1).toUpperCase() + parts[i].substring(1);
-        }
-        return java.util.Arrays.toString(parts).replace(", ", "").replaceAll("[\\[\\]]", "");
     }
 
     public boolean rubotoAttachable() {

--- a/assets/src/RubotoService.java
+++ b/assets/src/RubotoService.java
@@ -27,6 +27,7 @@ THE_CONSTANTS
 	
   @Override
   public void onCreate() {
+	System.out.println("RubotoService.onCreate()");
     args = new Object[0];
 
     super.onCreate();
@@ -37,7 +38,18 @@ THE_CONSTANTS
 
         try {
             if (scriptName != null) {
+                System.out.println("Loading service script: " + scriptName);
                 new Script(scriptName).execute();
+                String rubyClassName = Script.toCamelCase(scriptName);
+                System.out.println("Looking for Ruby class: " + rubyClassName);
+                Object rubyClass = Script.get(rubyClassName);
+                if (rubyClass != null) {
+                    System.out.println("Instanciating Ruby class: " + rubyClassName);
+                    Script.put("$java_service", this);
+                    Script.exec("$ruby_service = " + rubyClassName + ".new($java_service)");
+                    rubyInstance = Script.get("$ruby_service");
+                    Script.exec("$ruby_service.on_create");
+                }
             } else {
                 Script.execute("$service.initialize_ruboto");
                 Script.execute("$service.on_create");

--- a/assets/src/ruboto/service.rb
+++ b/assets/src/ruboto/service.rb
@@ -53,6 +53,14 @@ end
 
 module Ruboto
   module Service
+    def initialize(java_instance)
+      @java_instance = java_instance
+    end
+
+    def method_missing(method, *args, &block)
+      return @java_instance.send(method, *args, &block) if @java_instance.respond_to?(method)
+      super
+    end
   end
 end
 

--- a/lib/ruboto/util/update.rb
+++ b/lib/ruboto/util/update.rb
@@ -119,7 +119,7 @@ module Ruboto
               <contains string="${tests.output}" substring="INSTRUMENTATION_FAILED"/>
               <contains string="${tests.output}" substring="FAILURES"/>
               <not>
-                <matches string="${tests.output}" pattern="OK \\(\\d+ tests\\)" multiline="true"/>
+                <matches string="${tests.output}" pattern="OK \\(\\d+ tests?\\)" multiline="true"/>
               </not>
             </or>
           </condition>

--- a/test/activity/stack_activity_test.rb
+++ b/test/activity/stack_activity_test.rb
@@ -19,12 +19,13 @@ test('stack depth') do |activity|
     }[org.ruboto.Script.platform_version_name] || [0, 0, 0, 0]
   else
     jruby_offset = {
+        '1.7.0.dev' => [1, 1, 1, 1],
         '1.7.0.preview1' => [0, -1, -1, -1],
     }[org.jruby.runtime.Constants::VERSION] || [0, 0, 0, 0]
   end
   version_message ="ANDROID: #{android.os.Build::VERSION::SDK_INT}, PLATFORM: #{org.ruboto.Script.uses_platform_apk ? org.ruboto.Script.platform_version_name : 'STANDALONE'}, JRuby: #{org.jruby.runtime.Constants::VERSION}"
-  assert_equal 44 + os_offset + jruby_offset[0], activity.find_view_by_id(42).text.to_i, version_message
-  assert_equal 49 + os_offset + jruby_offset[1], activity.find_view_by_id(43).text.to_i, version_message
+  assert_equal 43 + os_offset + jruby_offset[0], activity.find_view_by_id(42).text.to_i, version_message
+  assert_equal 48 + os_offset + jruby_offset[1], activity.find_view_by_id(43).text.to_i, version_message
   assert_equal 49 + os_offset + jruby_offset[2], activity.find_view_by_id(44).text.to_i, version_message
   assert_equal 82 + os_offset + jruby_offset[3], activity.find_view_by_id(45).text.to_i, version_message
 end

--- a/test/block_def_activity/stack_activity_test.rb
+++ b/test/block_def_activity/stack_activity_test.rb
@@ -19,12 +19,13 @@ test('stack depth') do |activity|
     }[org.ruboto.Script.platform_version_name] || [0, 0, 0, 0]
   else
     jruby_offset = {
+        '1.7.0.dev' => [1, 1, 1, 1],
         '1.7.0.preview1' => [0, -1, -1, -1],
     }[org.jruby.runtime.Constants::VERSION] || [0, 0, 0, 0]
   end
   version_message ="ANDROID: #{android.os.Build::VERSION::SDK_INT}, PLATFORM: #{org.ruboto.Script.uses_platform_apk ? org.ruboto.Script.platform_version_name : 'STANDALONE'}, JRuby: #{org.jruby.runtime.Constants::VERSION}"
-  assert_equal 44 + os_offset + jruby_offset[0], activity.find_view_by_id(42).text.to_i, version_message
-  assert_equal 68 + os_offset + jruby_offset[1], activity.find_view_by_id(43).text.to_i, version_message
-  assert_equal 77 + os_offset + jruby_offset[2], activity.find_view_by_id(44).text.to_i, version_message
-  assert_equal 93 + os_offset + jruby_offset[3], activity.find_view_by_id(45).text.to_i, version_message
+  assert_equal 43 + os_offset + jruby_offset[0], activity.find_view_by_id(42).text.to_i, version_message
+  assert_equal 67 + os_offset + jruby_offset[1], activity.find_view_by_id(43).text.to_i, version_message
+  assert_equal 76 + os_offset + jruby_offset[2], activity.find_view_by_id(44).text.to_i, version_message
+  assert_equal 92 + os_offset + jruby_offset[3], activity.find_view_by_id(45).text.to_i, version_message
 end

--- a/test/handle_activity/stack_activity_test.rb
+++ b/test/handle_activity/stack_activity_test.rb
@@ -19,12 +19,13 @@ test('stack depth') do |activity|
     }[org.ruboto.Script.platform_version_name] || [0, 0, 0, 0]
   else
     jruby_offset = {
+        '1.7.0.dev' => [1, 1, 1, 1],
         '1.7.0.preview1' => [0, -1, -1, -1],
     }[org.jruby.runtime.Constants::VERSION] || [0, 0, 0, 0]
   end
   version_message ="ANDROID: #{android.os.Build::VERSION::SDK_INT}, PLATFORM: #{org.ruboto.Script.uses_platform_apk ? org.ruboto.Script.platform_version_name : 'STANDALONE'}, JRuby: #{org.jruby.runtime.Constants::VERSION}"
-  assert_equal 44 + os_offset + jruby_offset[0], activity.find_view_by_id(42).text.to_i, version_message
-  assert_equal 68 + os_offset + jruby_offset[1], activity.find_view_by_id(43).text.to_i, version_message
-  assert_equal 77 + os_offset + jruby_offset[2], activity.find_view_by_id(44).text.to_i, version_message
-  assert_equal 93 + os_offset + jruby_offset[3], activity.find_view_by_id(45).text.to_i, version_message
+  assert_equal 43 + os_offset + jruby_offset[0], activity.find_view_by_id(42).text.to_i, version_message
+  assert_equal 67 + os_offset + jruby_offset[1], activity.find_view_by_id(43).text.to_i, version_message
+  assert_equal 76 + os_offset + jruby_offset[2], activity.find_view_by_id(44).text.to_i, version_message
+  assert_equal 92 + os_offset + jruby_offset[3], activity.find_view_by_id(45).text.to_i, version_message
 end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -2,7 +2,7 @@ require File.expand_path("test_helper", File.dirname(__FILE__))
 require 'fileutils'
 
 class ServiceTest < Test::Unit::TestCase
-  SRC_DIR ="#{APP_DIR}/src"
+  SRC_DIR = "#{APP_DIR}/src"
 
   def setup
     generate_app
@@ -15,14 +15,65 @@ class ServiceTest < Test::Unit::TestCase
   def test_service_startup
     Dir.chdir APP_DIR do
       system "#{RUBOTO_CMD} gen class Service --name RubotoTestService"
+
+      activity_filename = "#{SRC_DIR}/ruboto_test_app_activity.rb"
+      assert File.exists? activity_filename
+      File.open(activity_filename, 'w') { |f| f << <<EOF }
+require 'ruboto/activity'
+require 'ruboto/widget'
+
+ruboto_import_widgets :Button, :LinearLayout, :TextView
+
+class RubotoTestAppActivity
+  include Ruboto::Activity
+
+  def on_create(bundle)
+    $ruboto_test_app_activity = self
+    set_title 'Domo arigato, Mr Ruboto!'
+
+    self.content_view =
+        linear_layout :orientation => :vertical do
+          @text_view = text_view :text    => 'What hath Matz wrought?', :id => 42, :width => :fill_parent,
+                                 :gravity => android.view.Gravity::CENTER, :text_size => 48.0
+          button :text => 'M-x butterfly', :width => :fill_parent, :id => 43, :on_click_listener => proc { butterfly }
+        end
+  rescue
+    puts "Exception creating activity: \#{$!}"
+    puts $!.backtrace.join("\\n")
+  end
+
+  def set_text(text)
+    @text_view.text = text
+  end
+
+  private
+
+  def butterfly
+    puts 'butterfly'
+    Thread.start do
+      begin
+        startService(android.content.Intent.new(application_context, $package.RubotoTestService.java_class))
+      rescue Exception
+        puts "Exception starting the service: \#{$!}"
+        puts $!.backtrace.join("\\n")
+      end
+    end
+    puts 'butterfly OK'
+  end
+
+end
+EOF
+
       service_filename = "#{SRC_DIR}/ruboto_test_service.rb"
       assert File.exists? service_filename
       File.open(service_filename, 'w') { |f| f << <<EOF }
 require 'ruboto/service'
 
 class RubotoTestService
+  TARGET_TEXT = 'What hath Matz wrought!'
   include Ruboto::Service
   def on_create
+    puts "service on_create"
     Thread.start do
       loop do
         sleep 1
@@ -30,27 +81,56 @@ class RubotoTestService
       end
     end
     puts "\#{self.class} started."
+
+    $ruboto_test_app_activity.set_title 'on_create'
+
     android.app.Service::START_STICKY
   end
 
   def on_start_command(intent, flags, start_id)
+    puts "service on_start_command(\#{intent}, \#{flags}, \#{start_id})"
+    getApplication()
+    getApplication
+    get_application
+    application
+
+    $ruboto_test_app_activity.set_title 'on_start_command'
+    $ruboto_test_app_activity.set_text TARGET_TEXT
+
     android.app.Service::START_STICKY
   end
 end
 EOF
 
-      activity_filename = "#{SRC_DIR}/ruboto_test_app_activity.rb"
-      s                 = File.read(activity_filename)
-      s.gsub!(/^(end)$/, "
-  def on_resume
-    startService(android.content.Intent.new(application_context, $package.RubotoTestService.java_class))
-  end
+      service_test_filename = "#{APP_DIR}/test/src/ruboto_test_app_activity_test.rb"
+      assert File.exists? service_test_filename
+      File.open(service_test_filename, 'w') { |f| f << <<EOF }
+activity Java::org.ruboto.test_app.RubotoTestAppActivity
 
-  def on_pause
-    stopService(android.content.Intent.new(application_context, $package.RubotoTestService.java_class))
+setup do |activity|
+  start = Time.now
+  loop do
+    @text_view = activity.findViewById(42)
+    break if @text_view || (Time.now - start > 60)
+    sleep 1
   end
-\\1\n")
-      File.open(activity_filename, 'w') { |f| f << s }
+  assert @text_view
+end
+
+test 'button changes text', :ui => false do |activity|
+  button = activity.findViewById(43)
+  puts 'Clicking...'
+  activity.run_on_ui_thread{button.performClick}
+  puts 'Clicked!'
+  start = Time.now
+  loop do
+    break if @text_view.text == 'What hath Matz wrought!' || (Time.now - start > 60)
+    sleep 1
+  end
+  assert_equal 'What hath Matz wrought!', @text_view.text
+end
+EOF
+
     end
     run_app_tests
   end


### PR DESCRIPTION
@ruboto @rscottm @headius 
- Added support and test for Service

Now defining and starting a Service using a class definition works.

Please review and merge.

Next step is to ensure (by test) that starting of activities and services without dedicated Java classes also works.  For services this means starting the defined RubotoService entry with a Script argument in the Intent Bundle. I am thinking maybe we should offer a mechanism to push a block of code to the default RubotoService and let that block be run by the default RubotoService, maybe in a thread per block.
