### PR TITLE
* Eliminate the use of global variables when using class-based defiition of Activity, Service, and BroadcastReceiver!

### DIFF
--- a/assets/src/RubotoActivity.java
+++ b/assets/src/RubotoActivity.java
@@ -68,12 +68,15 @@ THE_CONSTANTS
         }
     }
 
+    // TODO(uwe):  Only needed for non-class-based definitions
+    // Can be removed if we stop supporting non-class-based definitions
     // This causes JRuby to initialize and takes a while.
     protected void prepareJRuby() {
     	JRubyAdapter.put("$context", this);
     	JRubyAdapter.put("$activity", this);
     	JRubyAdapter.put("$bundle", args[0]);
     }
+    // TODO end
 
     protected void loadScript() {
         try {
@@ -84,14 +87,12 @@ THE_CONSTANTS
                 if (rubyClass == null) {
                     System.out.println("Loading script: " + scriptName);
                     JRubyAdapter.exec(new Script(scriptName).getContents());
+                    rubyClass = JRubyAdapter.get(rubyClassName);
                 }
-                rubyClass = JRubyAdapter.get(rubyClassName);
                 if (rubyClass != null) {
                     System.out.println("Instanciating Ruby class: " + rubyClassName);
-                    JRubyAdapter.put("$java_activity", this);
-                    JRubyAdapter.exec("$ruby_activity = " + rubyClassName + ".new($java_activity)");
-                    rubyInstance = JRubyAdapter.get("$ruby_activity");
-                    JRubyAdapter.exec("$ruby_activity.on_create($bundle)");
+                    rubyInstance = JRubyAdapter.callMethod(rubyClass, "new", this, Object.class);
+                    JRubyAdapter.callMethod(rubyInstance, "on_create", args[0]);
                 }
             } else if (configBundle != null) {
                 // TODO: Why doesn't this work?

--- a/assets/src/RubotoBroadcastReceiver.java
+++ b/assets/src/RubotoBroadcastReceiver.java
@@ -32,18 +32,25 @@ public class THE_RUBOTO_CLASS THE_ACTION THE_ANDROID_CLASS {
     }
 
     protected void loadScript() {
+
+        // TODO(uwe):  Only needed for non-class-based definitions
+        // Can be removed if we stop supporting non-class-based definitions
     	JRubyAdapter.put("$broadcast_receiver", this);
+    	// TODO end
+
         if (scriptName != null) {
             try {
-                JRubyAdapter.exec(new Script(scriptName).getContents());
                 String rubyClassName = Script.toCamelCase(scriptName);
                 System.out.println("Looking for Ruby class: " + rubyClassName);
                 Object rubyClass = JRubyAdapter.get(rubyClassName);
+                if (rubyClass == null) {
+                    System.out.println("Loading script: " + scriptName);
+                    JRubyAdapter.exec(new Script(scriptName).getContents());
+                    rubyClass = JRubyAdapter.get(rubyClassName);
+                }
                 if (rubyClass != null) {
                     System.out.println("Instanciating Ruby class: " + rubyClassName);
-                    JRubyAdapter.put("$java_broadcast_receiver", this);
-                    JRubyAdapter.exec("$ruby_broadcast_receiver = " + rubyClassName + ".new($java_broadcast_receiver)");
-                    rubyInstance = JRubyAdapter.get("$ruby_broadcast_receiver");
+                    rubyInstance = JRubyAdapter.callMethod(rubyClass, "new", this, Object.class);
                 }
             } catch(IOException e) {
                 throw new RuntimeException("IOException loading broadcast receiver script", e);
@@ -54,13 +61,16 @@ public class THE_RUBOTO_CLASS THE_ACTION THE_ANDROID_CLASS {
     public void onReceive(android.content.Context context, android.content.Intent intent) {
         try {
             System.out.println("onReceive: " + rubyInstance);
-            JRubyAdapter.put("$context", context);
-            JRubyAdapter.put("$broadcast_receiver", this);
-            JRubyAdapter.put("$intent", intent);
             if (rubyInstance != null) {
-            	JRubyAdapter.exec("$ruby_broadcast_receiver.on_receive($context, $intent)");
+            	JRubyAdapter.callMethod(rubyInstance, "on_receive", new Object[]{context, intent});
             } else {
+                // TODO(uwe):  Only needed for non-class-based definitions
+                // Can be removed if we stop supporting non-class-based definitions
+                JRubyAdapter.put("$context", context);
+                JRubyAdapter.put("$broadcast_receiver", this);
+                JRubyAdapter.put("$intent", intent);
             	JRubyAdapter.execute("$broadcast_receiver.on_receive($context, $intent)");
+            	// TODO end
             }
         } catch(Exception e) {
             e.printStackTrace();

--- a/test/activity/stack_activity.rb
+++ b/test/activity/stack_activity.rb
@@ -15,10 +15,10 @@ class StackActivity
     self.content_view =
         linear_layout :orientation => :vertical, :gravity => android.view.Gravity::CENTER do
           stack_depth_linear_layout = java.lang.Thread.current_thread.stack_trace.length.to_s
-          @script_view              = text_view :id => 42, :text => STACK_DEPTH_SCRIPT, :text_size => 48.0, :gravity => android.view.Gravity::CENTER
-          @class_view               = text_view :id => 43, :text => STACK_DEPTH_CLASS, :text_size => 48.0, :gravity => android.view.Gravity::CENTER
-          @handle_create_view       = text_view :id => 44, :text => stack_depth_on_create, :text_size => 48.0, :gravity => android.view.Gravity::CENTER
-          @linear_layout_view       = text_view :id => 45, :text => stack_depth_linear_layout, :text_size => 48.0, :gravity => android.view.Gravity::CENTER
+          text_view :id => 42, :text => STACK_DEPTH_SCRIPT, :text_size => 48.0, :gravity => android.view.Gravity::CENTER
+          text_view :id => 43, :text => STACK_DEPTH_CLASS, :text_size => 48.0, :gravity => android.view.Gravity::CENTER
+          text_view :id => 44, :text => stack_depth_on_create, :text_size => 48.0, :gravity => android.view.Gravity::CENTER
+          text_view :id => 45, :text => stack_depth_linear_layout, :text_size => 48.0, :gravity => android.view.Gravity::CENTER
         end
   end
 end

--- a/test/activity/stack_activity_test.rb
+++ b/test/activity/stack_activity_test.rb
@@ -27,6 +27,6 @@ test('stack depth') do |activity|
   version_message ="ANDROID: #{android.os.Build::VERSION::SDK_INT}, PLATFORM: #{org.ruboto.JRubyAdapter.uses_platform_apk ? org.ruboto.JRubyAdapter.platform_version_name : 'STANDALONE'}, JRuby: #{org.jruby.runtime.Constants::VERSION}"
   assert_equal 43 + os_offset + jruby_offset[0], activity.find_view_by_id(42).text.to_i, version_message
   assert_equal 48 + os_offset + jruby_offset[1], activity.find_view_by_id(43).text.to_i, version_message
-  assert_equal 49 + os_offset + jruby_offset[2], activity.find_view_by_id(44).text.to_i, version_message
-  assert_equal 82 + os_offset + jruby_offset[3], activity.find_view_by_id(45).text.to_i, version_message
+  assert_equal 46 + os_offset + jruby_offset[2], activity.find_view_by_id(44).text.to_i, version_message
+  assert_equal 79 + os_offset + jruby_offset[3], activity.find_view_by_id(45).text.to_i, version_message
 end


### PR DESCRIPTION
Follow up of Issue #190.

This removes the use of global variables when using class-based definition of Activity, Service, and BroadcastReceiver.

It also removes 3 stack frames when calling on_create!

@rscottm @ruboto @ruboto/team-ruboto-core 

Please review and merge.  I'll be starting the release process tomorrow.
