### PR TITLE
Adding detection of mingw/mswin and using the appropriate command

### DIFF
--- a/lib/ruboto/sdk_versions.rb
+++ b/lib/ruboto/sdk_versions.rb
@@ -6,7 +6,7 @@ module Ruboto
     MINIMUM_SUPPORTED_SDK = "android-#{MINIMUM_SUPPORTED_SDK_LEVEL}"
     DEFAULT_TARGET_SDK_LEVEL = 8
     DEFAULT_TARGET_SDK = "android-#{DEFAULT_TARGET_SDK_LEVEL}"
-    ANDROID_HOME = ENV['ANDROID_HOME'] || File.dirname(File.dirname(Pathname.new(`which adb`.chomp).realpath))
+    ANDROID_HOME = ENV['ANDROID_HOME'] || File.dirname(File.dirname(Pathname.new(`#{RUBY_PLATFORM =~ /mingw|mswin/ ? "where" : "which"} adb`.chomp).realpath))
     ANDROID_TOOLS_REVISION = File.read("#{ANDROID_HOME}/tools/source.properties").slice(/Pkg.Revision=\d+/).slice(/\d+$/).to_i
   end
 end


### PR DESCRIPTION
Enabling detection of mingw/mswin terminals and using the appropriate command.
It may be worth to note that powershell uses its own version of the command which works with its own objects rather than the system.
