### PR TITLE
Fixed signing bug

### DIFF
--- a/assets/rakelib/ruboto.rake
+++ b/assets/rakelib/ruboto.rake
@@ -116,7 +116,7 @@ task :tag => :release do
 end
 
 task :sign => :release do
-  sh "jarsigner -keystore #{ENV['RUBOTO_KEYSTORE']} -signedjar bin/#{build_project_name}.apk bin/#{build_project_name}-unsigned.apk #{ENV['RUBOTO_KEY_ALIAS']}"
+  sh "jarsigner -keystore #{ENV['RUBOTO_KEYSTORE']} -signedjar bin/#{build_project_name}.apk bin/#{build_project_name}-release-unsigned.apk #{ENV['RUBOTO_KEY_ALIAS']}"
 end
 
 task :align => :sign do


### PR DESCRIPTION
`rake publish` fails, attempting to sign a file that doesn't exist. By modifying the rake file template, future projects won't have this problem.
