### PR TITLE
Change references to APK_FILE in rake install task.

### DIFF
--- a/assets/rakelib/ruboto.rake
+++ b/assets/rakelib/ruboto.rake
@@ -561,7 +561,7 @@ def install_apk
     install_retry_count = 0
     begin
       timeout 120 do
-        output = `adb install -r #{APK_FILE} 2>&1`
+        output = `adb install -r "#{APK_FILE}" 2>&1`
       end
     rescue Timeout::Error
       puts "Installing package #{package} timed out."
@@ -571,7 +571,7 @@ def install_apk
         retry
       end
       puts 'Trying one final time to install the package:'
-      output = `adb install -r #{APK_FILE} 2>&1`
+      output = `adb install -r "#{APK_FILE}" 2>&1`
     end
     if $? == 0 && output !~ failure_pattern && output =~ success_pattern
       clear_update
@@ -594,7 +594,7 @@ def install_apk
   install_retry_count = 0
   begin
     timeout 120 do
-      output = `adb install #{APK_FILE} 2>&1`
+      output = `adb install "#{APK_FILE}" 2>&1`
     end
   rescue Timeout::Error
     puts "Installing package #{package} timed out."
@@ -604,7 +604,7 @@ def install_apk
       retry
     end
     puts 'Trying one final time to install the package:'
-    output = `adb install #{APK_FILE} 2>&1`
+    output = `adb install "#{APK_FILE}" 2>&1`
   end
   puts output
   raise "Install failed (#{$?}) #{$1 ? "[#$1}]" : output}" if $? != 0 || output =~ failure_pattern || output !~ success_pattern


### PR DESCRIPTION
APK_FILE, when used in the command prompt outputs, needs quotation
marks just in case the APK_FILE resides in a path with spaces in it.
