### PR TITLE
* Issue #224 Smoother RubotoCore installation

### DIFF
--- a/assets/src/org/ruboto/EntryPointActivity.java
+++ b/assets/src/org/ruboto/EntryPointActivity.java
@@ -370,10 +370,12 @@ public class EntryPointActivity extends org.ruboto.RubotoActivity {
                 Log.d("onActivityResult: Install OK.");
             } else if (resultCode == RESULT_CANCELED) {
                 Log.d("onActivityResult: Install canceled.");
+                // FIXME(uwe): Maybe show a dialog explaining that RubotoCore is needed and try again?
                 deleteFile(RUBOTO_APK);
                 if (!JRubyAdapter.isInitialized()) {
                     finish();
                 }
+                // EMXIF
             } else {
                 Log.e("onActivityResult: resultCode: " + resultCode);
             }


### PR DESCRIPTION
Ruboto apps with the INTERNET permission can download and install Ruboto core directly on devices that allow installation from unknown sources.

@rscottm could you review and merge?
