### PR TITLE
Added check for compatible APIs for update examples: re issue #437

### DIFF
--- a/test/ruboto_update_test.rb
+++ b/test/ruboto_update_test.rb
@@ -9,24 +9,54 @@ require File.expand_path('updated_example_test_methods', File.dirname(__FILE__))
 require File.expand_path('update_test_methods', File.dirname(__FILE__))
 
 # TODO(uwe): Delete obsolete examples when we stop supporting updating from them.
-
 Dir.chdir "#{RubotoTest::PROJECT_DIR}/examples/" do
   example_archives = Dir["#{RubotoTest::APP_NAME}_*_tools_r*.tgz"]
   example_archives = example_archives.sort_by{|a| Gem::Version.new a[RubotoTest::APP_NAME.size + 1..-1].slice(/(.*)(?=_tools_)/)}
   example_archives = example_archives.last(example_limit) if example_limit
-  example_archives.each do |f|
-    next unless f =~ /^#{RubotoTest::APP_NAME}_(.*)_tools_r(.*)\.tgz$/
-    ruboto_version = $1
-    tools_version = $2
+
+  # TODO(gf): Track APIs compatible with update examples
+  EXAMPLE_COMPATIBLE_APIS = { (Gem::Version.new("0.7.0")..Gem::Version.new("0.10.99")) => [8],
+                              (Gem::Version.new("0.11.0")..Gem::Version.new("0.13.0")) => [10,11,12,13,14,15,16,17] }
+
+  installed_apis = `android list target --compact`.lines.grep(/^android-/) { |s| s.match(/\d+/).to_s.to_i }
+  examples = example_archives.collect { |f| f.match /^#{RubotoTest::APP_NAME}_(?<ruboto_version>.*)_tools_r(?<tools_version>.*)\.tgz$/ }.compact
+
+  missing_apis = false
+  puts "Backward compatibility update tests: #{examples.size}"
+  examples.each_with_index do |m,i|
+    example_gem_version = Gem::Version.new m[:ruboto_version]
+    compatible_apis = EXAMPLE_COMPATIBLE_APIS[ EXAMPLE_COMPATIBLE_APIS.keys.detect { |gem_range| gem_range.cover? example_gem_version } ]
+    if compatible_apis
+      if ( installed_apis & compatible_apis ).empty?
+        puts "Update test #{examples[i]} needs a missing compatible API: #{compatible_apis.join(',')}"
+        missing_apis = true
+      end
+    end
+  end
+
+  if missing_apis
+    puts '----------------------------------------------------------------------------------------------------'
+    puts 'Required android APIs are missing, resolution options are:'
+    puts '* Install a needed android API with "android update sdk --no-ui --all --filter android-XX"'
+    puts '* Skip all backward compatibility update tests with "SKIP_RUBOTO_UPDATE_TEST=DEFINED rake test"'
+    puts '* Limit number of backward compatibility update tests to N with "RUBOTO_UPDATE_EXAMPLES=N rake test"'
+    puts 'Quitting...'
+    exit false
+  end
+
+  examples.each do |m|
+    ruboto_version = m[:ruboto_version]
+    tools_version = m[:tools_version]
+    ruboto_version_no_dots = ruboto_version.gsub('.', '_')
     self.class.class_eval <<EOF
-class RubotoUpdatedExample#{ruboto_version.gsub('.', '_')}Tools#{tools_version}Test < Test::Unit::TestCase
+class RubotoUpdatedExample#{ruboto_version_no_dots}Tools#{tools_version}Test < Test::Unit::TestCase
   include UpdatedExampleTestMethods
   def setup
     super('#{ruboto_version}', '#{tools_version}')
   end
 end
 
-class RubotoUpdate#{ruboto_version.gsub('.', '_')}Tools#{tools_version}Test < Test::Unit::TestCase
+class RubotoUpdate#{ruboto_version_no_dots}Tools#{tools_version}Test < Test::Unit::TestCase
   include UpdateTestMethods
   def setup
     super('#{ruboto_version}', '#{tools_version}')
@@ -34,4 +64,5 @@ class RubotoUpdate#{ruboto_version.gsub('.', '_')}Tools#{tools_version}Test < Te
 end
 EOF
   end
+
 end


### PR DESCRIPTION
Environment requirements for backwards compatibility is probably always going to be an issue (#437), a hard-coded fix doesn't feel like enough.
So, possibly running afoul of YAGNI, I got a little carried away and added the ability to track compatible APIs for update examples (You may want to reduce the API list for the range 0.11.0 to 0.13.0.).

```
EXAMPLE_COMPATIBLE_APIS = {
  (Gem::Version.new("0.7.0")..Gem::Version.new("0.10.99")) => [8],
  (Gem::Version.new("0.11.0")..Gem::Version.new("0.13.0")) => [10,11,12,13,14,15,16,17]
} 
```

Any update example versions not listed get a free pass.
To save wasting time on a doomed test run, check is performed for all update examples (after consideration of RUBOTO_UPDATE_EXAMPLES and SKIP_RUBOTO_UPDATE_TEST) before creating any update tests.
Advice is given for resolution. 
