### PR TITLE
Fix android_package_directory for ones already installed android sdk

### DIFF
--- a/lib/ruboto/util/setup.rb
+++ b/lib/ruboto/util/setup.rb
@@ -407,7 +407,7 @@ module Ruboto
             a = STDIN.gets.chomp.upcase
           end
           if accept_all || a == 'Y' || a.empty?
-            update_cmd = "android --silent update sdk --no-ui --filter build-tools-#{get_tools_version('build-tool')},platform-tool,tool --force"
+            update_cmd = "android --silent update sdk --no-ui --filter build-tools-#{get_tools_version('build-tool')},platform-tool,tool -a --force"
             update_sdk(update_cmd, accept_all)
             check_for_build_tools
             check_for_platform_tools


### PR DESCRIPTION
#452

ruboto setup now detect the installed android sdk path before downloading a new one into HOME.
in my installation: 

> asakawa at ArchLinux in ~/Projects
> $ ruboto setup
> Java runtime             : Found
> Java Compiler            : Found
> Apache ANT               : Found
> Android Package Installer: Found
> Android Emulator         : Found
> Android SDK Command adb  : Found
> Android SDK Command dx   : Found
> Platform SDK android-10  : Found
>     **\* Ruboto setup is OK! ***
> You are missing some paths.  Execute these lines to add them:
>     export PATH="/home/asakawa/Softwares/adt-bundle-linux-x86_64/sdk/build-tools/android-4.2.2:$PATH"
> Would you like to append these lines to your configuration script? (Y/n): 
