### PR TITLE
Fix #451 by locking screen orientation of SplashActivity

### DIFF
--- a/lib/ruboto/util/update.rb
+++ b/lib/ruboto/util/update.rb
@@ -302,7 +302,7 @@ module Ruboto
           end
 
           unless app_element.elements["activity[@android:name='org.ruboto.SplashActivity']"]
-            app_element.add_element 'activity', {'android:name' => 'org.ruboto.SplashActivity', 'android:exported' => 'false'}
+            app_element.add_element 'activity', {'android:name' => 'org.ruboto.SplashActivity', 'android:exported' => 'false', 'android:screenOrientation' => 'portrait'}
           end
 
           unless app_element.elements["activity[@android:name='org.ruboto.RubotoDialog']"]


### PR DESCRIPTION
#451

As we now have a new SplashActivity which separates the startup code with user activity. I think that it doesn't matter to directly lock the orientation of splash screen which may cause app crashing when we change it. 
