### PR TITLE
rake log

### DIFF
--- a/assets/rakelib/ruboto.rake
+++ b/assets/rakelib/ruboto.rake
@@ -492,6 +492,35 @@ Java::json.ext.ParserService.new.basicLoad(JRuby.runtime)
   FileUtils.rm_rf BUNDLE_PATH
 end
 
+desc 'Log activity execution, accepts optional logcat filter'
+task :logcat, [:filter] do |t,args|
+  puts "--- clearing logcat"
+  `adb logcat -c`
+  filter = args[:filter] ? args[:filter] : ''          # filter log with filter-specs like TAG:LEVEL TAG:LEVEL ... '*:S'
+  logcat_cmd = "adb logcat ActivityManager #{filter}"  # we always need ActivityManager logging to catch activity start
+  puts "--- starting logcat: #{logcat_cmd}"
+  IO.popen logcat_cmd do |logcat|
+    puts "--- waiting for activity #{package}/.#{main_activity} ..."
+    activity_started = false
+    started_regex   = Regexp.new "^\\I/ActivityManager.+Start proc #{package} for activity #{package}/\\.#{main_activity}: pid=(?<pid>\\d+)"
+    restarted_regex = Regexp.new "^\\I/ActivityManager.+START u0 {cmp=#{package}/org.ruboto.RubotoActivity.+} from pid (?<pid>\\d+)"
+    related_regex   = Regexp.new "#{package}|#{main_activity}"
+    pid_regex = nil
+    logcat.each_line do |line|
+      if activity_start_match = started_regex.match( line ) || restarted_regex.match( line )
+        activity_started = true
+        pid = activity_start_match[:pid]
+        pid_regex = Regexp.new "\\( *#{pid}\\): "
+        puts "--- activity PID=#{pid}"
+      end
+      if activity_started && ( line =~ pid_regex || line =~ related_regex )
+        puts "#{Time.now.strftime('%Y%m%d %H%M%S.%6N')} #{line}"
+      end
+    end
+    puts '--- logcat closed'
+  end
+end
+
 # Methods
 
 def sdk_level
@@ -687,3 +716,4 @@ def stop_app
   output = `adb shell ps | grep #{package} | awk '{print $2}' | xargs adb shell kill`
   output !~ /Operation not permitted/
 end
+


### PR DESCRIPTION
A rake task to filter logcat output to show only logs relevant to the application.

```
$ rake --describe logcat
rake logcat[filter]
    Log activity execution, accepts optional logcat filter
```
- Watches for ActivityManager logging to detect application process ID.
- Filters for lines from the application process only.
- Includes relevant logs from Ruboto, DavlikVM, and any part of the Android system executing in the application's process.
- Prepends timestamp make log review easier.
- Accepts options logcat filters.

Example:

```
$ rake logcat
--- clearing logcat
--- starting logcat: adb logcat ActivityManager 
--- waiting for activity net.iqeo.wifimap/.WifiMapActivity ...
20130909 205304.477000 I/ActivityManager(  527): START u0 {cmp=net.iqeo.wifimap/org.ruboto.RubotoActivity (has extras)} from pid 24965
20130909 205304.503000 I/System.out(24965): RubotoActivity onCreate(): org.ruboto.RubotoActivity
20130909 205304.504000 D/RUBOTO  (24965): Looking for Ruby class: WifiMapMainActivity
20130909 205304.505000 D/RUBOTO  (24965): Found: #<Class:#<Java::OrgRuboto::RubotoActivity:0x431c6d98>>
20130909 205304.506000 D/RUBOTO  (24965): Checking path: /storage/emulated/0/Android/data/net.iqeo.wifimap/files/scripts/wifi_map_main_activity.rb
20130909 205304.507000 D/RUBOTO  (24965): Checking path: scripts/wifi_map_main_activity.rb
20130909 205304.508000 D/RUBOTO  (24965): Classpath resource: jar:file:/data/app/net.iqeo.wifimap-2.apk!/wifi_map_main_activity.rb
20130909 205304.508000 D/RUBOTO  (24965): Found script.
20130909 205304.509000 D/RUBOTO  (24965): Checking path: /storage/emulated/0/Android/data/net.iqeo.wifimap/files/scripts/wifi_map_main_activity.rb
20130909 205304.510000 D/RUBOTO  (24965): Checking path: scripts/wifi_map_main_activity.rb
20130909 205304.512000 D/RUBOTO  (24965): Classpath resource: jar:file:/data/app/net.iqeo.wifimap-2.apk!/wifi_map_main_activity.rb
20130909 205304.528000 D/RUBOTO  (24965): Script defines methods on meta class
20130909 205304.530000 D/RUBOTO  (24965): Loading script: wifi_map_main_activity.rb
20130909 205304.530000 D/RUBOTO  (24965): Script contains class definition
20130909 205304.531000 D/RUBOTO  (24965): Set class: #<Class:#<Java::OrgRuboto::RubotoActivity:0x43472c40>>
20130909 205304.532000 D/RUBOTO  (24965): Checking path: /storage/emulated/0/Android/data/net.iqeo.wifimap/files/scripts/wifi_map_main_activity.rb
20130909 205304.533000 D/RUBOTO  (24965): Checking path: scripts/wifi_map_main_activity.rb
20130909 205304.537000 D/RUBOTO  (24965): Classpath resource: jar:file:/data/app/net.iqeo.wifimap-2.apk!/wifi_map_main_activity.rb
20130909 205304.893000 D/RUBOTO  (24965): Script load took 362ms
20130909 205304.898000 D/RUBOTO  (24965): Call onCreate on: org.ruboto.RubotoActivity@43d50bb0
20130909 205304.903000 I/WifiMap (24965): WifiMapMainActivity: +on_create
20130909 205304.905000 I/System.out(24965): RubotoActivity onCreate(): org.ruboto.RubotoActivity
20130909 205304.907000 I/WifiMap (24965): Map: +init
20130909 205304.909000 I/WifiMap (24965): MapDbHelper: +initialize
20130909 205304.914000 I/WifiMap (24965): MapDbHelper: -initialize
20130909 205304.917000 I/WifiMap (24965): Map: -init
20130909 205304.922000 I/WifiMap (24965): WifiMapMainActivity:   +create_view
```
