### PR TITLE
Add weight to widget.rb

### DIFF
--- a/assets/src/ruboto/widget.rb
+++ b/assets/src/ruboto/widget.rb
@@ -52,6 +52,10 @@ View.class_eval do
     if height = params.delete(:height)
       getLayoutParams.height = View.convert_constant(height)
     end
+    
+    if weight = params.delete(:weight)
+      getLayoutParams.weight = View.convert_constant(weight)
+    end
 
     if margins = params.delete(:margins)
       getLayoutParams.set_margins(*margins)


### PR DESCRIPTION
This is required to allow ruboto to evenly split the remaining space in a linear layout.
