### PR TITLE
Update emulator.rb (Fix no emulator window shows in MacOS 10.9 with Virtualbox 4.3, when $DISPLAY variable is empty)

### DIFF
--- a/lib/ruboto/util/emulator.rb
+++ b/lib/ruboto/util/emulator.rb
@@ -29,7 +29,7 @@ module Ruboto
         end
 
         emulator_opts = '-partition-size 256'
-        if !ON_WINDOWS && ENV['DISPLAY'].nil?
+        if !ON_MAC_OS_X && !ON_WINDOWS && ENV['DISPLAY'].nil?
           emulator_opts << ' -no-window -no-audio'
         end
 


### PR DESCRIPTION
Fix no emulator window shows in MacOS 10.9 with Virtualbox 4.3, when $DISPLAY variable is empty
