### PR TITLE
Fixed match for SDK release versions

### DIFF
--- a/lib/ruboto/util/setup.rb
+++ b/lib/ruboto/util/setup.rb
@@ -144,9 +144,9 @@ module Ruboto
         end
 
         link = page_content.scan(/#{regex}/).to_s
-        version = link.match( /(\d+).(\d+).(\d+)/ )[0]
+        version = link.match( /r(\d+).(\d+).(\d+)|r(\d+).(\d+)|r(\d+)/ )[0]
 
-        version
+        version.delete! 'r'
       end
 
       #########################################


### PR DESCRIPTION
This is the fix to issue #636 
It will now match all three forms 
(a) r23-linux.tgz
(b) r23.0-linux.tgz
(c) r23.0.1-linux.tgz
