### PR TITLE
generate java methods in the build process only for implemented ruby met...

### DIFF
--- a/assets/assets/MethodProxiesTemplate.java.erb
+++ b/assets/assets/MethodProxiesTemplate.java.erb
@@ -1,0 +1,25 @@
+package <%= package %>;
+<% component = component == 'Activity' ? 'EntryPointActivity' : "Ruboto#{component}" %>
+
+import org.ruboto.JRubyAdapter;
+import org.ruboto.ScriptLoader;
+import org.ruboto.ScriptInfo;
+import org.ruboto.<%= component %>;
+import org.ruboto.Log;
+
+public class <%= class_name %>MethodProxies extends <%= component %> {
+
+    private final ScriptInfo scriptInfo = new ScriptInfo();
+
+    protected boolean relayToRuby(String method) {
+        if (!JRubyAdapter.isInitialized()) {
+            Log.i("Method called before JRuby runtime was initialized: " +
+                    method);
+            return false;
+        }
+        return !ScriptLoader.isCalledFromJRuby() &&
+            scriptInfo.getRubyInstance() != null;
+    }
+
+<%= method_definitions %>
+}

--- a/assets/assets/MethodProxyTemplate.java.erb
+++ b/assets/assets/MethodProxyTemplate.java.erb
@@ -1,0 +1,17 @@
+<% void = return_type == 'void' %>
+<% return_prefix = void ? '' : 'return ' %>
+    public <%= return_type %> <%= method_name %>(<%= parameters %>) {
+        if(relayToRuby("<%= class_name %>#<%= method_name %>")) {
+            <%= return_prefix %><%= void ? '' : "(#{return_type}) " %>
+JRubyAdapter.runRubyMethod(
+<% unless void %>
+                <%= return_type %>.class,
+<% end %>
+                scriptInfo.getRubyInstance(),
+                "<%= ruby_method_name %>"<% unless parameter_names.empty? %>,
+                new Object[]{<%= parameter_names %>}
+            <% end %>);
+        } else {
+            <%= return_prefix %>super.<%= method_name %>(<%= parameter_names %>);
+        }
+    }

--- a/assets/src/InheritingActivity.java
+++ b/assets/src/InheritingActivity.java
@@ -1,4 +1,4 @@
 package THE_PACKAGE;
 
-public class InheritingActivity extends org.ruboto.EntryPointActivity {
+public class InheritingActivity extends InheritingActivityMethodProxies {
 }

--- a/assets/src/InheritingBroadcastReceiver.java
+++ b/assets/src/InheritingBroadcastReceiver.java
@@ -2,5 +2,5 @@ package THE_PACKAGE;
 
 import org.ruboto.JRubyAdapter;
 
-public class InheritingBroadcastReceiver extends org.ruboto.RubotoBroadcastReceiver {
+public class InheritingBroadcastReceiver extends InheritingBroadcastReceiverMethodProxies {
 }

--- a/assets/src/InheritingService.java
+++ b/assets/src/InheritingService.java
@@ -1,4 +1,4 @@
 package THE_PACKAGE;
 
-public class InheritingService extends org.ruboto.RubotoService {
+public class InheritingService extends InheritingServiceMethodProxies {
 }

--- a/lib/ruboto/commands/base.rb
+++ b/lib/ruboto/commands/base.rb
@@ -130,6 +130,7 @@ module Ruboto
                     update_dx_jar true
                   end
                   update_core_classes 'exclude'
+                  generate_method_proxy_api_asset
 
                   log_action('Generating the default Activity and script') do
                     generate_inheriting_file 'Activity', activity, package
@@ -304,7 +305,7 @@ module Ruboto
                 required
                 argument :required
                 validate { |i| %w(all on none).include?(i) }
-                defaults 'on'
+                defaults 'none'
                 description 'the base set of methods to generate (adjusted with method_include and method_exclude): all, none, on (e.g., onClick)'
               }
 
@@ -337,6 +338,7 @@ module Ruboto
 
               def run
                 abort("specify 'implements' only for Activity, Service, BroadcastReceiver, PreferenceActivity, or TabActivity") unless %w(Activity Service BroadcastReceiver PreferenceActivity TabActivity).include?(params['class'].value) or params['implements'].value == ''
+                params[:method_include] += ',onCreate,onDestroy,onBind'
                 generate_core_classes [:class, :method_base, :method_include, :method_exclude, :implements, :force].inject({}) { |h, i| h[i] = params[i.to_s].value; h }
               end
             end
@@ -398,6 +400,7 @@ module Ruboto
                 update_icons force
                 update_core_classes 'exclude'
                 update_bundle
+                generate_method_proxy_api_asset
               end
             end
 

--- a/lib/ruboto/util/update.rb
+++ b/lib/ruboto/util/update.rb
@@ -377,13 +377,13 @@ module Ruboto
       end
 
       def update_core_classes(force = nil)
-        generate_core_classes(:class => 'all', :method_base => 'on', :method_include => '', :method_exclude => '', :force => force, :implements => '')
+        generate_core_classes(:class => 'all', :method_base => 'none', :method_include => 'onCreate,onDestroy,onBind', :method_exclude => '', :force => force, :implements => '')
         if File.exists?('ruboto.yml')
           sleep 1
           FileUtils.touch 'ruboto.yml'
         end
         Dir['src/*_activity.rb'].each{|f|FileUtils.touch(f)}
-        system 'rake build_xml jruby_adapter ruboto_activity'
+        system 'rake build_xml jruby_adapter'
       end
 
       def read_ruboto_version


### PR DESCRIPTION
This is a proof of concept implementation for an alternative way of generating the java method proxies that relay the calls to the ruby implementation.

This method stores the Android API metadata for Activity et al as a ruby hash in asset files inside the project dir.
When building the project, a rake task obtains all implemented method names from the ruby source (as previously) and then writes proxy methods into an intermediate superclass of the Activity, in which the method is called directly, avoiding the need to test different spelling variants. (I would propose to actually require the source file and read the methods from the class object, in order to allow inheritance and modules for the ruby class, but I don't know whether this can be done reliably.)
The code is generated via erb templates, because ruboto's templating engine is a little confusing to read and this is the canonical and clean way to generate code in my opinion.

This commit handles only a small part of the classes and edge cases and there are several workarounds where a sensible implementation should be created by a maintainer, so this PR is only an RFC, not intended to be merged. Please tell me what you think of it!