### PR TITLE
Update setup.rb

### DIFF
--- a/lib/ruboto/util/setup.rb
+++ b/lib/ruboto/util/setup.rb
@@ -612,7 +612,7 @@ module Ruboto
         if accept_all
           IO.popen(update_cmd, 'r+') do |cmd_io|
             begin
-              output = ''
+              output = ''.encode('UTF-8', :invalid => :replace)
               question_pattern = /.*Do you accept the license '[a-z-]+-[0-9a-f]{8}' \[y\/n\]: /m
               STDOUT.sync = true
               cmd_io.each_char do |text|


### PR DESCRIPTION
Fixes "invalid byte sequence in UTF-8" on Mac OS X 10.9.5
