### PR TITLE
feat: Add travis after_success release Rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,3 +93,5 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
+after_success:
+  - rake release


### PR DESCRIPTION
@donv 
Is this something you had in mind?

Travis also provides another way to deploy to RubyGems, detailed [here](https://docs.travis-ci.com/user/deployment/rubygems/#Releasing-build-artifacts).

As for S3, I am not sure how to proceed. The free tier lasts for only 12 months. Dropbox is also another way to go about it, although Travis does not have an inbuilt solution for it.