### PR TITLE
Replace --no-ri compatibility with the new versions of gem

### DIFF
--- a/lib/ruboto/util/update.rb
+++ b/lib/ruboto/util/update.rb
@@ -222,9 +222,9 @@ module Ruboto
           local_gem_dir = ENV['LOCAL_GEM_DIR'] || Dir.getwd
           local_gem_file = "#{local_gem_dir}/jruby-jars-#{jruby_jars_version}.gem"
           if File.exists?(local_gem_file)
-            system "gem install -l #{local_gem_file} --no-ri --no-rdoc"
+            system "gem install -l #{local_gem_file} --no-document"
           else
-            system "gem install -r jruby-jars#{version_requirement} --no-ri --no-rdoc"
+            system "gem install -r jruby-jars#{version_requirement} --no-document"
           end
         end
         raise "install of jruby-jars failed with return code #$?" unless $? == 0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,7 @@ module RubotoTest
   end
 
   `gem query -i -n bundler`
-  system 'gem install bundler --no-ri --no-rdoc' unless $? == 0
+  system 'gem install bundler --no-document' unless $? == 0
   `bundle check`
   system 'bundle --system' unless $? == 0
   lib_path = File.expand_path('lib', File.dirname(File.dirname(__FILE__)))
@@ -70,7 +70,7 @@ module RubotoTest
   def install_ruboto_gem(version)
     version_requirement = "-v #{version}"
     `gem query -i -n ^ruboto$ #{version_requirement}`
-    system "gem install ruboto #{version_requirement} --no-ri --no-rdoc" unless $? == 0
+    system "gem install ruboto #{version_requirement} --no-document" unless $? == 0
     raise "install of ruboto #{version} failed with return code #$?" unless $? == 0
   end
 


### PR DESCRIPTION
--no-ri switch has been removed from gem, causing project creation to fail. This commit replaces --no-ri --no-rdoc with the new switch doing both, --no-document.